### PR TITLE
Prepare project for Vercel deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,21 @@ The AI Help-Center is a production-ready Node.js service that wraps Google Gemin
    npm start
    ```
 
+5. **Deploy to Vercel**
+
+   The repository ships with a ready-to-use [`vercel.json`](./vercel.json) configuration and a catch-all serverless function in [`api/[[...path]].mjs`](./api/[[...path]].mjs). To deploy:
+
+   ```bash
+   npm install -g vercel
+   vercel login
+   vercel link
+   vercel env pull            # optional: sync local .env
+   vercel env add NAME VALUE  # add required env vars
+   vercel deploy --prod
+   ```
+
+   The build step compiles the TypeScript sources (`npm run build`) before bundling the serverless handler. All `/api/*` requests are routed through the Express app, so the same endpoints work locally and on Vercel.
+
 ## API
 
 ### `POST /api/ask`
@@ -124,7 +139,8 @@ src/
 ├── retrieval/             # Lightweight knowledge base loader and retriever
 ├── routes/                # Express routers
 ├── middleware/            # Error handling utilities
-└── index.ts               # Express server entrypoint
+├── index.ts               # Express app factory exported for tests & serverless
+└── server.ts              # Node.js runtime entrypoint for local/VM hosting
 ```
 
 ## License

--- a/api/[[...path]].mjs
+++ b/api/[[...path]].mjs
@@ -1,0 +1,11 @@
+import app, { knowledgeReady } from '../dist/index.js';
+
+export default async function handler(req, res) {
+  try {
+    await knowledgeReady;
+  } catch (error) {
+    console.error('Knowledge base initialization failed before handling request:', error);
+  }
+
+  return app(req, res);
+}

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Production-grade AI Help Center application using Gemini with RAG and citations.",
   "type": "module",
   "scripts": {
-    "dev": "tsx watch src/index.ts",
-    "start": "node dist/index.js",
+    "dev": "tsx watch src/server.ts",
+    "start": "node dist/server.js",
     "build": "tsc -p tsconfig.json",
     "test": "vitest run"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ export const knowledgeReady = initializeKnowledgeBase().catch((error) => {
   console.error('Knowledge base initialization failed:', error);
 });
 
-const geminiClient = new GeminiClient({
+export const geminiClient = new GeminiClient({
   apiKey: AppConfig.gemini.apiKey,
   model: AppConfig.gemini.model,
   baseUrl: AppConfig.gemini.baseUrl,
@@ -64,20 +64,5 @@ app.use('/api', createAskRouter(geminiClient, retriever));
 
 app.use(notFoundHandler);
 app.use(errorHandler);
-
-if (process.env.NODE_ENV !== 'test') {
-  knowledgeReady
-    .catch(() => {
-      // initialization errors are already logged above
-    })
-    .finally(() => {
-      app.listen(AppConfig.port, () => {
-        console.log(`AI Help-Center server running on port ${AppConfig.port}`);
-        if (!geminiClient.isConfigured()) {
-          console.warn('Gemini API key not configured. The /api/ask endpoint will return request payloads only.');
-        }
-      });
-    });
-}
 
 export default app;

--- a/src/routes/ask.ts
+++ b/src/routes/ask.ts
@@ -13,10 +13,19 @@ const retrievedDocSchema = z.object({
   created_at: z.string().optional(),
 });
 
+const workspaceSchema = z
+  .object({
+    name: z.string(),
+    brand: z.string().optional(),
+    tone: z.string().optional(),
+    locale: z.string().optional(),
+  })
+  .catchall(z.unknown());
+
 const askSchema = z.object({
   question: z.string().min(1),
-  workspace: z.record(z.any()).optional(),
-  policies: z.record(z.any()).optional(),
+  workspace: workspaceSchema.optional(),
+  policies: z.record(z.unknown()).optional(),
   retrieved_docs: z.array(retrievedDocSchema).optional(),
   mode: z.enum(['markdown', 'json']).optional(),
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,21 @@
+import { AppConfig } from './config.js';
+import app, { geminiClient, knowledgeReady } from './index.js';
+
+export const startServer = async () => {
+  await knowledgeReady;
+
+  const server = app.listen(AppConfig.port, () => {
+    console.log(`AI Help-Center server running on port ${AppConfig.port}`);
+    if (!geminiClient.isConfigured()) {
+      console.warn('Gemini API key not configured. The /api/ask endpoint will return request payloads only.');
+    }
+  });
+
+  return server;
+};
+
+if (process.env.NODE_ENV !== 'test' && process.env.VERCEL !== '1') {
+  startServer().catch((error) => {
+    console.error('Failed to start AI Help-Center server:', error);
+  });
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "ESNext",
+    "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,11 @@
+{
+  "version": 2,
+  "functions": {
+    "api/[[...path]].mjs": {
+      "runtime": "nodejs20.x"
+    }
+  },
+  "installCommand": "npm install",
+  "buildCommand": "npm run build",
+  "framework": null
+}


### PR DESCRIPTION
## Summary
- add Vercel configuration and a catch-all serverless handler that reuses the Express app
- separate Express bootstrap logic into a reusable app module and a Node runtime entrypoint
- tighten request validation to match workspace typing and document the Vercel workflow

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d3c7afdcd0833386169060683df7c5