### PR TITLE
Add dataset upload API and SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,68 @@ Generate an answer for a user question.
 }
 ```
 
+### `POST /api/datasets`
+
+Upload or replace knowledge base documents so the retriever stays up to date.
+
+- Accepts a list of document objects that mirror the `RetrievedDoc` shape.
+- Supports an optional `mode` flag:
+  - `append` (default) upserts documents into the current store.
+  - `replace` clears the existing store before inserting the new dataset.
+- When Supabase credentials are configured the documents are synced to the Supabase table. Otherwise they are persisted to `data/knowledgeBase.json`.
+
+**Example request**
+
+```json
+{
+  "mode": "append",
+  "documents": [
+    {
+      "title": "Billing policies",
+      "text": "Invoices are generated on the 1st of every month.",
+      "url": "https://example.com/docs/billing",
+      "created_at": "2024-05-01T12:00:00Z"
+    }
+  ]
+}
+```
+
+**Example response**
+
+```json
+{
+  "message": "Dataset updated successfully.",
+  "mode": "append",
+  "uploaded": 1,
+  "total": 6,
+  "source": "file"
+}
+```
+
+## SDK
+
+The project ships with a lightweight TypeScript SDK so you can integrate the Help Center from any front-end or server without manually crafting HTTP requests.
+
+```ts
+import { AiHelpCenterClient } from '@/lib/sdk';
+
+const client = new AiHelpCenterClient({ baseUrl: 'https://your-deployment.com' });
+
+// Ask the chatbot
+const answer = await client.ask('How do I reset my password?', { mode: 'markdown' });
+
+// Sync new knowledge base entries
+await client.uploadDataset([
+  {
+    title: 'Release notes',
+    text: 'Highlights for the latest product release.',
+    url: 'https://example.com/release-notes'
+  }
+]);
+```
+
+You can override the request paths or provide a custom `fetch` implementation when instantiating the client if you need to route through a proxy or supply authentication headers.
+
 ## Deployment
 
 The repository includes a minimal [`vercel.json`](./vercel.json). Deploy with Vercel or any Next.js-compatible platform:

--- a/app/api/datasets/route.ts
+++ b/app/api/datasets/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server';
+import { ZodError } from 'zod';
+
+import { handleDatasetUpload } from '@/lib/server/datasets';
+import { datasetStore, knowledgeReady, retriever, supabaseKnowledgeBase } from '@/lib/server/runtime';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: Request) {
+  try {
+    const payload = await request.json();
+    await knowledgeReady;
+    const result = await handleDatasetUpload(payload, {
+      retriever,
+      datasetStore,
+      supabaseKnowledgeBase,
+    });
+
+    return NextResponse.json(result.body, { status: result.status });
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      return NextResponse.json({ error: 'Invalid JSON payload.' }, { status: 400 });
+    }
+
+    if (error instanceof ZodError) {
+      return NextResponse.json(
+        {
+          error: 'Invalid dataset payload.',
+          details: error.errors,
+        },
+        { status: 400 },
+      );
+    }
+
+    console.error('Unexpected error while handling /api/datasets request:', error);
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/lib/sdk/client.ts
+++ b/lib/sdk/client.ts
@@ -1,0 +1,104 @@
+import type { AskRequestPayload, RetrievedDoc } from '@/lib/types';
+
+export interface AiHelpCenterClientConfig {
+  baseUrl: string;
+  askPath?: string;
+  datasetPath?: string;
+  fetch?: typeof fetch;
+  defaultHeaders?: Record<string, string>;
+}
+
+export type AskOptions = Omit<AskRequestPayload, 'question'>;
+
+export type DatasetDocumentInput = Omit<RetrievedDoc, 'id'> & { id?: string };
+
+export interface DatasetUploadOptions {
+  mode?: 'append' | 'replace';
+}
+
+export class AiHelpCenterClient {
+  private readonly baseUrl: string;
+  private readonly askPath: string;
+  private readonly datasetPath: string;
+  private readonly fetchImpl: typeof fetch;
+  private readonly defaultHeaders: Record<string, string>;
+
+  constructor(config: AiHelpCenterClientConfig) {
+    if (!config.baseUrl) {
+      throw new Error('baseUrl is required to initialize the AI Help Center client.');
+    }
+
+    const fetchImpl = config.fetch ?? globalThis.fetch;
+    if (!fetchImpl) {
+      throw new Error('Fetch API is not available in this environment. Provide a fetch implementation.');
+    }
+
+    this.baseUrl = config.baseUrl.replace(/\/+$/, '');
+    this.askPath = config.askPath ?? '/api/ask';
+    this.datasetPath = config.datasetPath ?? '/api/datasets';
+    this.fetchImpl = fetchImpl;
+    this.defaultHeaders = config.defaultHeaders ?? {};
+  }
+
+  public async ask(question: string, options: AskOptions = {}) {
+    if (!question || question.trim().length === 0) {
+      throw new Error('question is required when calling ask().');
+    }
+
+    const payload: AskRequestPayload = {
+      ...options,
+      question,
+    };
+
+    return this.postJson(this.askPath, payload, 'Failed to submit ask request');
+  }
+
+  public async uploadDataset(documents: DatasetDocumentInput[], options: DatasetUploadOptions = {}) {
+    if (!Array.isArray(documents) || documents.length === 0) {
+      throw new Error('At least one document is required when uploading a dataset.');
+    }
+
+    const payload = {
+      documents,
+      mode: options.mode ?? 'append',
+    };
+
+    return this.postJson(this.datasetPath, payload, 'Failed to upload dataset');
+  }
+
+  private async postJson(path: string, body: unknown, errorContext: string) {
+    const response = await this.fetchImpl(this.buildUrl(path), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...this.defaultHeaders,
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      let errorDetail: string;
+      try {
+        errorDetail = await response.text();
+      } catch {
+        errorDetail = response.statusText;
+      }
+
+      throw new Error(`${errorContext} (status ${response.status}): ${errorDetail}`);
+    }
+
+    return response.json();
+  }
+
+  private buildUrl(path: string): string {
+    if (path.startsWith('http://') || path.startsWith('https://')) {
+      return path;
+    }
+
+    if (!path.startsWith('/')) {
+      return `${this.baseUrl}/${path}`;
+    }
+
+    return `${this.baseUrl}${path}`;
+  }
+}

--- a/lib/sdk/index.ts
+++ b/lib/sdk/index.ts
@@ -1,0 +1,7 @@
+export { AiHelpCenterClient } from '@/lib/sdk/client';
+export type {
+  AiHelpCenterClientConfig,
+  AskOptions,
+  DatasetDocumentInput,
+  DatasetUploadOptions,
+} from '@/lib/sdk/client';

--- a/lib/server/datasetStore.ts
+++ b/lib/server/datasetStore.ts
@@ -1,0 +1,57 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+
+import { loadKnowledgeBase } from '@/lib/retrieval/knowledgeBase';
+import type { RetrievedDoc } from '@/lib/types';
+
+const dedupeDocuments = (documents: RetrievedDoc[]): RetrievedDoc[] => {
+  const map = new Map<string, RetrievedDoc>();
+  for (const doc of documents) {
+    map.set(doc.id, doc);
+  }
+
+  return Array.from(map.values());
+};
+
+export class DatasetStore {
+  private documents: RetrievedDoc[] = [];
+  private loaded = false;
+
+  constructor(private readonly filePath: string) {}
+
+  public load(): RetrievedDoc[] {
+    this.documents = loadKnowledgeBase(this.filePath);
+    this.loaded = true;
+    return this.documents;
+  }
+
+  private ensureLoaded() {
+    if (!this.loaded) {
+      this.load();
+    }
+  }
+
+  public getDocuments(): RetrievedDoc[] {
+    this.ensureLoaded();
+    return this.documents;
+  }
+
+  public replace(documents: RetrievedDoc[]): RetrievedDoc[] {
+    this.loaded = true;
+    this.documents = dedupeDocuments(documents);
+    return this.documents;
+  }
+
+  public append(documents: RetrievedDoc[]): RetrievedDoc[] {
+    this.ensureLoaded();
+    this.documents = dedupeDocuments([...this.documents, ...documents]);
+    return this.documents;
+  }
+
+  public async persist(): Promise<void> {
+    this.ensureLoaded();
+    const absolutePath = resolve(this.filePath);
+    await mkdir(dirname(absolutePath), { recursive: true });
+    await writeFile(absolutePath, JSON.stringify(this.documents, null, 2), 'utf-8');
+  }
+}

--- a/lib/server/datasets.ts
+++ b/lib/server/datasets.ts
@@ -1,0 +1,94 @@
+import { randomUUID } from 'node:crypto';
+
+import { z } from 'zod';
+
+import type { SupabaseKnowledgeBase } from '@/lib/retrieval/knowledgeBase';
+import type { SimpleRetriever } from '@/lib/retrieval/retriever';
+import type { RetrievedDoc } from '@/lib/types';
+import type { DatasetStore } from '@/lib/server/datasetStore';
+
+const datasetDocumentSchema = z
+  .object({
+    id: z.string().min(1).optional(),
+    title: z.string().min(1),
+    url: z.string().url(),
+    text: z.string().min(1),
+    created_at: z.string().optional(),
+  })
+  .catchall(z.unknown());
+
+export const datasetUploadSchema = z.object({
+  documents: z.array(datasetDocumentSchema).min(1),
+  mode: z.enum(['append', 'replace']).default('append'),
+});
+
+export type DatasetUploadPayload = z.infer<typeof datasetUploadSchema>;
+
+export interface DatasetHandlerDependencies {
+  retriever: SimpleRetriever;
+  datasetStore: DatasetStore;
+  supabaseKnowledgeBase?: SupabaseKnowledgeBase | null;
+}
+
+export interface DatasetHandlerResult {
+  status: number;
+  body: {
+    message: string;
+    mode: DatasetUploadPayload['mode'];
+    uploaded: number;
+    total: number;
+    source: 'supabase' | 'file';
+  };
+}
+
+const ensureDocumentId = (doc: z.infer<typeof datasetDocumentSchema>): RetrievedDoc => {
+  const { id, ...rest } = doc;
+  return {
+    ...(rest as Omit<RetrievedDoc, 'id'>),
+    id: id && id.length > 0 ? id : randomUUID(),
+  } as RetrievedDoc;
+};
+
+export async function handleDatasetUpload(
+  payload: unknown,
+  { retriever, datasetStore, supabaseKnowledgeBase }: DatasetHandlerDependencies,
+): Promise<DatasetHandlerResult> {
+  const input = datasetUploadSchema.parse(payload);
+  const normalizedDocuments = input.documents.map(ensureDocumentId);
+
+  let allDocuments: RetrievedDoc[] = [];
+  let source: DatasetHandlerResult['body']['source'] = 'file';
+
+  if (supabaseKnowledgeBase) {
+    if (input.mode === 'replace') {
+      await supabaseKnowledgeBase.replaceDocuments(normalizedDocuments);
+    } else {
+      await supabaseKnowledgeBase.upsertDocuments(normalizedDocuments);
+    }
+
+    allDocuments = await supabaseKnowledgeBase.fetchDocuments();
+    source = 'supabase';
+  } else {
+    if (input.mode === 'replace') {
+      datasetStore.replace(normalizedDocuments);
+    } else {
+      datasetStore.append(normalizedDocuments);
+    }
+
+    await datasetStore.persist();
+    allDocuments = datasetStore.getDocuments();
+  }
+
+  retriever.updateDocuments(allDocuments);
+
+  return {
+    status: 200,
+    body: {
+      message: 'Dataset updated successfully.',
+      mode: input.mode,
+      uploaded: normalizedDocuments.length,
+      total: allDocuments.length,
+      source,
+    },
+  };
+}

--- a/lib/server/runtime.ts
+++ b/lib/server/runtime.ts
@@ -1,19 +1,25 @@
 import { AppConfig } from '@/lib/config';
 import { GeminiClient } from '@/lib/gemini/client';
-import { loadKnowledgeBase, SupabaseKnowledgeBase } from '@/lib/retrieval/knowledgeBase';
+import { SupabaseKnowledgeBase } from '@/lib/retrieval/knowledgeBase';
 import { createRetriever } from '@/lib/retrieval/retriever';
+import { DatasetStore } from '@/lib/server/datasetStore';
 
 export const retriever = createRetriever([]);
 
-const initializeKnowledgeBase = async () => {
-  if (AppConfig.supabase.url && AppConfig.supabase.key) {
-    try {
-      const supabaseKnowledgeBase = new SupabaseKnowledgeBase({
+export const datasetStore = new DatasetStore(AppConfig.knowledgeBasePath);
+
+export const supabaseKnowledgeBase =
+  AppConfig.supabase.url && AppConfig.supabase.key
+    ? new SupabaseKnowledgeBase({
         url: AppConfig.supabase.url,
         key: AppConfig.supabase.key,
         table: AppConfig.supabase.table,
-      });
+      })
+    : null;
 
+const initializeKnowledgeBase = async () => {
+  if (supabaseKnowledgeBase) {
+    try {
       const documents = await supabaseKnowledgeBase.fetchDocuments();
 
       if (documents.length > 0) {
@@ -22,18 +28,22 @@ const initializeKnowledgeBase = async () => {
         return;
       }
 
-      console.warn('Supabase knowledge base returned no documents. Retrieval will rely on user-provided context.');
-      return;
+      console.warn(
+        'Supabase knowledge base returned no documents. Falling back to local JSON knowledge base if available.',
+      );
     } catch (error) {
       console.error('Unable to initialize Supabase knowledge base:', error);
     }
   }
 
-  const fallbackDocuments = loadKnowledgeBase(AppConfig.knowledgeBasePath);
+  const fallbackDocuments = datasetStore.load();
 
   if (fallbackDocuments.length > 0) {
     retriever.updateDocuments(fallbackDocuments);
-    console.warn('Supabase configuration missing. Using local JSON knowledge base for development.');
+    const fallbackReason = supabaseKnowledgeBase
+      ? 'Supabase returned no documents. Using local JSON knowledge base for retrieval.'
+      : 'Supabase configuration missing. Using local JSON knowledge base for development.';
+    console.warn(fallbackReason);
   } else {
     console.warn('No knowledge base documents loaded. Configure Supabase or provide retrieved_docs in requests.');
   }

--- a/tests/datasetHandler.test.ts
+++ b/tests/datasetHandler.test.ts
@@ -1,0 +1,123 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { describe, expect, it, vi } from 'vitest';
+import { ZodError } from 'zod';
+
+import { SimpleRetriever } from '@/lib/retrieval/retriever';
+import { DatasetStore } from '@/lib/server/datasetStore';
+import { handleDatasetUpload } from '@/lib/server/datasets';
+import type { SupabaseKnowledgeBase } from '@/lib/retrieval/knowledgeBase';
+
+const createDatasetStore = () => {
+  const dir = mkdtempSync(join(tmpdir(), 'ai-help-center-dataset-'));
+  const filePath = join(dir, 'knowledgeBase.json');
+  writeFileSync(filePath, '[]');
+  const store = new DatasetStore(filePath);
+  return { dir, filePath, store };
+};
+
+describe('handleDatasetUpload', () => {
+  it('persists documents to the local dataset store when Supabase is unavailable', async () => {
+    const { dir, filePath, store } = createDatasetStore();
+    const retriever = new SimpleRetriever([]);
+
+    try {
+      const result = await handleDatasetUpload(
+        {
+          documents: [
+            {
+              title: 'Getting Started',
+              text: 'Install the package and configure an API key.',
+              url: 'https://example.com/docs/getting-started',
+            },
+          ],
+        },
+        {
+          retriever,
+          datasetStore: store,
+        },
+      );
+
+      expect(result.status).toBe(200);
+      expect(result.body.source).toBe('file');
+      expect(result.body.total).toBe(1);
+
+      const stored = JSON.parse(readFileSync(filePath, 'utf-8'));
+      expect(stored).toHaveLength(1);
+      expect(stored[0].title).toBe('Getting Started');
+
+      const retrieved = retriever.retrieve('configure');
+      expect(retrieved).toHaveLength(1);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('delegates persistence to Supabase when configured', async () => {
+    const { dir, store } = createDatasetStore();
+    const retriever = new SimpleRetriever([]);
+
+    const supabase = {
+      replaceDocuments: vi.fn().mockResolvedValue(undefined),
+      upsertDocuments: vi.fn().mockResolvedValue(undefined),
+      fetchDocuments: vi
+        .fn()
+        .mockResolvedValue([
+          {
+            id: 'supabase-doc-1',
+            title: 'Policies',
+            text: 'Respect the community guidelines.',
+            url: 'https://example.com/policies',
+          },
+        ]),
+    } as unknown as SupabaseKnowledgeBase;
+
+    try {
+      const result = await handleDatasetUpload(
+        {
+          documents: [
+            {
+              id: 'supabase-doc-1',
+              title: 'Policies',
+              text: 'Respect the community guidelines.',
+              url: 'https://example.com/policies',
+            },
+          ],
+          mode: 'replace',
+        },
+        {
+          retriever,
+          datasetStore: store,
+          supabaseKnowledgeBase: supabase,
+        },
+      );
+
+      expect(supabase.replaceDocuments).toHaveBeenCalledTimes(1);
+      expect(supabase.fetchDocuments).toHaveBeenCalledTimes(1);
+      expect(result.body.source).toBe('supabase');
+      expect(result.body.total).toBe(1);
+      expect(retriever.retrieve('guidelines')).toHaveLength(1);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('validates the incoming payload', async () => {
+    const { dir, store } = createDatasetStore();
+    const retriever = new SimpleRetriever([]);
+
+    await expect(
+      handleDatasetUpload(
+        { documents: [] },
+        {
+          retriever,
+          datasetStore: store,
+        },
+      ),
+    ).rejects.toBeInstanceOf(ZodError);
+
+    rmSync(dir, { recursive: true, force: true });
+  });
+});

--- a/tests/sdk.test.ts
+++ b/tests/sdk.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { AiHelpCenterClient } from '@/lib/sdk/client';
+
+describe('AiHelpCenterClient', () => {
+  it('submits ask requests to the configured endpoint', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ response: { message: 'ok' } }),
+    });
+
+    const client = new AiHelpCenterClient({ baseUrl: 'https://help-center.example.com', fetch: fetchMock });
+
+    const result = await client.ask('How do I reset my password?', { mode: 'json' });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://help-center.example.com/api/ask',
+      expect.objectContaining({
+        method: 'POST',
+      }),
+    );
+
+    const [, requestInit] = fetchMock.mock.calls[0];
+    expect(requestInit?.headers).toMatchObject({ 'Content-Type': 'application/json' });
+    expect(JSON.parse(String(requestInit?.body))).toMatchObject({
+      question: 'How do I reset my password?',
+      mode: 'json',
+    });
+
+    expect(result).toEqual({ response: { message: 'ok' } });
+  });
+
+  it('uploads datasets with the selected mode', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ total: 3 }),
+    });
+
+    const client = new AiHelpCenterClient({ baseUrl: 'https://hosted.ai', fetch: fetchMock });
+
+    await client.uploadDataset(
+      [
+        {
+          title: 'FAQ',
+          text: 'Frequently asked questions',
+          url: 'https://example.com/faq',
+        },
+      ],
+      { mode: 'replace' },
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://hosted.ai/api/datasets',
+      expect.objectContaining({ method: 'POST' }),
+    );
+
+    const payload = JSON.parse(String(fetchMock.mock.calls[0][1]?.body));
+    expect(payload.mode).toBe('replace');
+    expect(payload.documents).toHaveLength(1);
+  });
+
+  it('throws when the API responds with an error status', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      text: async () => 'Server exploded',
+    });
+
+    const client = new AiHelpCenterClient({ baseUrl: 'https://hosted.ai', fetch: fetchMock });
+
+    await expect(client.ask('Is the service up?')).rejects.toThrow(/status 500/i);
+  });
+});


### PR DESCRIPTION
## Summary
- add a dataset upload handler and API route that persists documents to Supabase or the local JSON knowledge base
- introduce a file-backed dataset store and extend the runtime to share Supabase knowledge base access
- ship a TypeScript SDK with integration tests and documentation for asking questions and syncing datasets

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d3cf6a280c8333a508c62e3b9a4cb6