### PR TITLE
Add aichat Python client and documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,12 @@ node_modules
 .env
 dist
 .DS_Store
+__pycache__
+.venv
+*.egg-info
+*.pyc
+/.pytest_cache
+/.mypy_cache
 
 # Logs
 npm-debug.log*

--- a/README.md
+++ b/README.md
@@ -147,9 +147,12 @@ Upload or replace knowledge base documents so the retriever stays up to date.
 }
 ```
 
-## SDK
+## SDKs
 
-The project ships with a lightweight TypeScript SDK so you can integrate the Help Center from any front-end or server without manually crafting HTTP requests.
+The project ships with:
+
+- A lightweight TypeScript SDK so you can integrate the Help Center from any front-end or server without manually crafting HTTP requests.
+- A Python package named [`aichat`](./docs/aichat-python.md) that mirrors the TypeScript surface area for backend jobs, data pipelines, and notebook experiments.
 
 ```ts
 import { AiHelpCenterClient } from '@/lib/sdk';
@@ -170,6 +173,8 @@ await client.uploadDataset([
 ```
 
 You can override the request paths or provide a custom `fetch` implementation when instantiating the client if you need to route through a proxy or supply authentication headers.
+
+Python developers can follow the [aichat package guide](./docs/aichat-python.md) for installation, configuration, and publishing instructions.
 
 ## Deployment
 

--- a/docs/aichat-python.md
+++ b/docs/aichat-python.md
@@ -1,0 +1,350 @@
+# `aichat` Python Library
+
+The `aichat` package is a first-class Python client for the AI Help Center service that
+ships with this repository.  It mirrors the TypeScript SDK under `lib/sdk` so that backend
+jobs, data pipelines, or notebook experiments written in Python can submit questions,
+preview Gemini requests, and synchronise knowledge base documents with minimal boilerplate.
+This document explains *everything* you need to know to install, configure, and publish the
+library.
+
+> **Who is this guide for?**
+>
+> - Engineers embedding the Help Center into Django, FastAPI, or Flask services.
+> - Data teams that want to keep the knowledge base in sync from Airflow, Dagster, or cron.
+> - DevOps engineers tasked with packaging and releasing the Python SDK to PyPI.
+
+## Package overview
+
+| Item | Value |
+| --- | --- |
+| Distribution name | `aichat` |
+| Python support | 3.9 – 3.12 |
+| Transport | `requests` (synchronous HTTP) |
+| Source layout | `src/aichat/` with `py.typed` marker for type hints |
+| Key classes | `AiChatClient`, `AskOptions`, `DatasetDocumentInput`, `RetrievedDoc` |
+
+The client is intentionally small: it only wraps the `/api/ask` and `/api/datasets` routes
+provided by the Next.js application.  You can extend it with additional helpers, but the
+core surface area is purposely close to the TypeScript client so that docs and examples can
+be shared across languages.
+
+## Installing the client
+
+### From PyPI (recommended once published)
+
+```bash
+pip install aichat
+```
+
+### From a cloned repository
+
+1. Install build tooling (once per environment):
+
+   ```bash
+   python -m pip install --upgrade pip build
+   ```
+
+2. Build the wheel and source distribution:
+
+   ```bash
+   python -m build
+   ```
+
+   The artifacts will appear under `dist/`.  For local development you can install the
+   editable package directly:
+
+   ```bash
+   pip install -e .
+   ```
+
+3. Verify the installation:
+
+   ```bash
+   python -c "import aichat; print(aichat.__version__)"
+   ```
+
+### In isolated environments
+
+- **Virtualenv**
+
+  ```bash
+  python -m venv .venv
+  source .venv/bin/activate
+  pip install aichat
+  ```
+
+- **Poetry**
+
+  ```bash
+  poetry add aichat
+  ```
+
+- **Pipx**
+
+  Use pipx if you want to ship the library with a CLI wrapper:
+
+  ```bash
+  pipx install aichat
+  ```
+
+## Quick start
+
+```python
+from aichat import AiChatClient
+
+client = AiChatClient("https://your-help-center.example.com")
+response = client.ask(
+    "How do I reset my password?",
+    {
+        "mode": "markdown",
+        "workspace": {"name": "Acme Support", "tone": "friendly"},
+    },
+)
+
+print(response["response"]["candidates"][0])
+```
+
+> **Development mode:** when the server does not have `GEMINI_API_KEY` configured the API
+> responds with a request preview instead of contacting Gemini.  The client will happily
+> return that payload, which makes it perfect for unit tests and prompt inspection.
+
+## Configuring the client
+
+### Base URL and custom paths
+
+- `base_url` should point to the public deployment (e.g. `https://support.example.com`).
+- Override `ask_path` or `dataset_path` if your infrastructure rewrites routes (for
+  example, when placing the Next.js API behind a reverse proxy).
+
+```python
+client = AiChatClient(
+    "https://support.example.com",
+    ask_path="/v1/ask",
+    dataset_path="/v1/datasets",
+)
+```
+
+### Authentication and headers
+
+Attach API keys, session cookies, or auth tokens through `default_headers`:
+
+```python
+client = AiChatClient(
+    "https://support.example.com",
+    default_headers={
+        "Authorization": "Bearer $YOUR_TOKEN",
+        "X-Tenant": "enterprise",
+    },
+)
+```
+
+You can also pass a pre-configured `requests.Session` to reuse proxies, retry adapters, or
+custom TLS settings.
+
+### Timeouts and retry policies
+
+- `timeout` (default 30 seconds) controls how long to wait for the HTTP request.
+- For retries use `requests.adapters.HTTPAdapter` with the standard `urllib3` retry
+  support:
+
+  ```python
+  import requests
+  from requests.adapters import HTTPAdapter
+  from urllib3.util.retry import Retry
+
+  session = requests.Session()
+  retries = Retry(total=3, backoff_factor=0.5, status_forcelist=(500, 502, 503, 504))
+  session.mount("https://", HTTPAdapter(max_retries=retries))
+
+  client = AiChatClient("https://support.example.com", session=session)
+  ```
+
+## Asking questions
+
+### Minimal call
+
+```python
+client.ask("What is the refund policy?")
+```
+
+### Supplying retrieved documents
+
+Use `RetrievedDoc` or dictionaries.  The client normalises either representation.
+
+```python
+from aichat import RetrievedDoc, AskOptions
+
+retrieved_docs = [
+    RetrievedDoc(
+        id="kb-123",
+        title="Refund policy",
+        url="https://support.example.com/docs/refunds",
+        text="We offer 30 day refunds on all paid plans.",
+    )
+]
+
+options = AskOptions(retrieved_docs=retrieved_docs, mode="markdown")
+response = client.ask("Can I request a refund after 10 days?", options)
+```
+
+### Workspace and policy metadata
+
+```python
+client.ask(
+    "Do we support SSO?",
+    {
+        "workspace": {
+            "name": "Enterprise Support",
+            "brand": "Contoso",
+            "locale": "en-US",
+        },
+        "policies": {
+            "escalation_required": False,
+            "allowed_integrations": ["Okta", "AzureAD"],
+        },
+        "mode": "json",
+    },
+)
+```
+
+### Handling responses
+
+The API always returns JSON.  When Gemini is configured you will receive the model
+response under the `response` key.  Without an API key the payload has the structure shown
+below (ideal for testing and prompt debugging):
+
+```json
+{
+  "message": "Gemini API key not configured. Returning request payload for debugging.",
+  "request": { "model": "gemini-2.0-flash-001", "contents": [...] }
+}
+```
+
+Use defensive coding when extracting answers:
+
+```python
+payload = client.ask("Help me troubleshoot login issues")
+if "response" in payload:
+    content = payload["response"]["candidates"][0]
+else:
+    # Development mode preview
+    print(payload["request"]["contents"])  # inspect the generated prompt
+```
+
+### Error handling
+
+Network issues or non-2xx HTTP responses raise `AiChatError`.  Catch it to implement
+fallback behaviour:
+
+```python
+from aichat import AiChatError
+
+try:
+    client.ask("Is the API rate limited?")
+except AiChatError as exc:
+    logger.warning("Help Center call failed: %s", exc)
+```
+
+## Uploading datasets
+
+Synchronise the retriever with structured documents using
+`AiChatClient.upload_dataset()`.
+
+```python
+from datetime import datetime
+from aichat import DatasetDocumentInput, DatasetUploadOptions
+
+release_notes = DatasetDocumentInput(
+    title="Release notes",
+    text="Highlights from the June release.",
+    url="https://support.example.com/docs/june-release",
+    created_at=datetime.utcnow().isoformat() + "Z",
+)
+
+client.upload_dataset([release_notes], DatasetUploadOptions(mode="append"))
+```
+
+- `mode="append"` upserts documents into the existing store (default).
+- `mode="replace"` clears the store before inserting the new dataset.
+- Additional metadata can be attached through the `extras` field on
+  `DatasetDocumentInput` or by passing dictionaries.
+
+## Using the client as a context manager
+
+`AiChatClient` exposes `__enter__` / `__exit__` so the underlying session is closed
+cleanly:
+
+```python
+with AiChatClient("https://support.example.com") as client:
+    client.ask("Where can I update billing info?")
+```
+
+## Integration patterns
+
+### Server-side workflows
+
+- **Django or Flask** – keep a single `AiChatClient` on module scope to benefit from
+  connection pooling.
+- **Celery tasks** – instantiate the client inside the task and close it once the job
+  completes.
+- **FastAPI dependency injection** – declare the client as a dependency so request handlers
+  can call `ask()` or `upload_dataset()` without boilerplate.
+
+### Offline pipelines
+
+1. Export knowledge base content from your CMS.
+2. Transform it into the `DatasetDocumentInput` structure (ids optional).
+3. Call `upload_dataset(..., mode="replace")` at the end of the pipeline to refresh the
+   retriever before your next deploy.
+
+### Prompt experimentation
+
+When running `npm run dev`, omit `GEMINI_API_KEY`.  Every call from the Python client will
+return the Gemini request payload, letting you iterate on prompts directly in notebooks.
+
+## Publishing the library
+
+1. Ensure the version in `pyproject.toml` and `aichat.__version__` is updated.
+2. Run `python -m build` to produce the wheel (`.whl`) and source archive (`.tar.gz`).
+3. Inspect the built metadata:
+
+   ```bash
+   tar -tf dist/aichat-<version>.tar.gz | head
+   ```
+
+4. Upload to TestPyPI first:
+
+   ```bash
+   python -m pip install twine
+   python -m twine upload --repository testpypi dist/*
+   ```
+
+5. Verify installation from TestPyPI:
+
+   ```bash
+   pip install --index-url https://test.pypi.org/simple/ --no-deps aichat
+   ```
+
+6. Publish to the real index when satisfied:
+
+   ```bash
+   python -m twine upload dist/*
+   ```
+
+## Troubleshooting
+
+| Symptom | Fix |
+| --- | --- |
+| `AiChatError: Fetch API key not configured` | Ensure the Next.js deployment has `GEMINI_API_KEY` if you expect live generations. |
+| `ValueError: question must be a non-empty string` | Sanity check user input before forwarding to the client. |
+| `requests.exceptions.SSLError` | Attach a custom `requests.Session` with organisation-specific certificate bundles. |
+| Dataset uploads never persist | Confirm Supabase credentials are set on the server or that the filesystem is writeable. |
+
+## Reference
+
+- Source code: [`src/aichat/client.py`](../src/aichat/client.py)
+- TypeScript counterpart: [`lib/sdk/client.ts`](../lib/sdk/client.ts)
+- API contracts: [`lib/types.ts`](../lib/types.ts)
+
+The Python client intentionally mirrors these files.  When new fields are added to the API
+update both implementations to keep the documentation accurate.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,43 @@
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "aichat"
+version = "0.1.0"
+description = "Python client for the AI Help Center service"
+readme = {file = "docs/aichat-python.md", content-type = "text/markdown"}
+requires-python = ">=3.9"
+authors = [
+    {name = "AI Help Center Team"}
+]
+keywords = ["ai", "chatbot", "help-center", "gemini", "rag"]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Topic :: Internet :: WWW/HTTP",
+    "Topic :: Software Development :: Libraries",
+]
+dependencies = [
+    "requests>=2.31.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/example/aichat"
+Documentation = "https://github.com/example/aichat/tree/main/docs"
+Source = "https://github.com/example/aichat"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+include-package-data = true
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-data]
+"aichat" = ["py.typed"]

--- a/src/aichat/__init__.py
+++ b/src/aichat/__init__.py
@@ -1,0 +1,22 @@
+"""Python client for the AI Help Center service."""
+from __future__ import annotations
+
+from .client import (
+    AiChatClient,
+    AiChatError,
+    AskOptions,
+    DatasetDocumentInput,
+    DatasetUploadOptions,
+    RetrievedDoc,
+)
+
+__all__ = [
+    "AiChatClient",
+    "AiChatError",
+    "AskOptions",
+    "DatasetDocumentInput",
+    "DatasetUploadOptions",
+    "RetrievedDoc",
+]
+
+__version__ = "0.1.0"

--- a/src/aichat/client.py
+++ b/src/aichat/client.py
@@ -1,0 +1,266 @@
+"""HTTP client for interacting with the AI Help Center service.
+
+This module powers the :mod:`aichat` Python package.  It mirrors the behaviour of the
+TypeScript SDK that ships with the Next.js application so Python developers can trigger
+chat completions and upload datasets without manually crafting HTTP requests.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, Mapping, Optional, Sequence, Union
+import requests
+
+
+class AiChatError(RuntimeError):
+    """Base exception raised for client level failures."""
+
+
+@dataclass
+class RetrievedDoc:
+    """Representation of a document that can be sent to the retrieval pipeline."""
+
+    id: str
+    title: str
+    url: str
+    text: str
+    created_at: Optional[str] = None
+    extras: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_payload(self) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "id": self.id,
+            "title": self.title,
+            "url": self.url,
+            "text": self.text,
+        }
+        if self.created_at is not None:
+            payload["created_at"] = self.created_at
+        payload.update(dict(self.extras))
+        return payload
+
+
+@dataclass
+class DatasetDocumentInput:
+    """Document accepted by the dataset upload endpoint.
+
+    The identifier is optional because the API can generate one automatically when it is
+    omitted.
+    """
+
+    title: str
+    text: str
+    url: str
+    id: Optional[str] = None
+    created_at: Optional[str] = None
+    extras: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_payload(self) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "title": self.title,
+            "text": self.text,
+            "url": self.url,
+        }
+        if self.id is not None:
+            payload["id"] = self.id
+        if self.created_at is not None:
+            payload["created_at"] = self.created_at
+        payload.update(dict(self.extras))
+        return payload
+
+
+@dataclass
+class AskOptions:
+    """Optional parameters that can accompany an :class:`AiChatClient` ask request."""
+
+    workspace: Optional[Mapping[str, Any]] = None
+    retrieved_docs: Optional[Sequence[Union[RetrievedDoc, Mapping[str, Any]]]] = None
+    policies: Optional[Mapping[str, Any]] = None
+    mode: Optional[str] = None
+    extras: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_payload(self) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {}
+        if self.workspace is not None:
+            payload["workspace"] = dict(self.workspace)
+        if self.retrieved_docs is not None:
+            payload["retrieved_docs"] = [
+                _normalize_document(doc) for doc in self.retrieved_docs
+            ]
+        if self.policies is not None:
+            payload["policies"] = dict(self.policies)
+        if self.mode is not None:
+            payload["mode"] = self.mode
+        payload.update(dict(self.extras))
+        return payload
+
+
+@dataclass
+class DatasetUploadOptions:
+    """Customisation flags accepted by :meth:`AiChatClient.upload_dataset`."""
+
+    mode: str = "append"
+    extras: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_payload(self) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {"mode": self.mode}
+        payload.update(dict(self.extras))
+        return payload
+
+
+class AiChatClient:
+    """High level HTTP client for the AI Help Center API."""
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        ask_path: str = "/api/ask",
+        dataset_path: str = "/api/datasets",
+        session: Optional[requests.Session] = None,
+        default_headers: Optional[Mapping[str, str]] = None,
+        timeout: Optional[float] = 30.0,
+    ) -> None:
+        if not base_url or not base_url.strip():
+            raise ValueError("base_url is required to initialize AiChatClient.")
+
+        self._base_url = base_url.rstrip("/")
+        self._ask_path = ask_path
+        self._dataset_path = dataset_path
+        self._session = session or requests.Session()
+        self._default_headers = dict(default_headers or {})
+        self._timeout = timeout
+
+    @property
+    def base_url(self) -> str:
+        return self._base_url
+
+    def ask(
+        self,
+        question: str,
+        options: Optional[Union[AskOptions, Mapping[str, Any]]] = None,
+    ) -> Dict[str, Any]:
+        if not question or not question.strip():
+            raise ValueError("question must be a non-empty string.")
+
+        payload: Dict[str, Any] = {"question": question}
+        if options is not None:
+            payload.update(_normalize_ask_options(options))
+
+        return self._post_json(self._ask_path, payload, "Failed to submit ask request")
+
+    def upload_dataset(
+        self,
+        documents: Sequence[Union[DatasetDocumentInput, Mapping[str, Any]]],
+        options: Optional[Union[DatasetUploadOptions, Mapping[str, Any]]] = None,
+    ) -> Dict[str, Any]:
+        if not isinstance(documents, Sequence) or len(documents) == 0:
+            raise ValueError("At least one document is required when uploading a dataset.")
+
+        normalized_docs = [_normalize_dataset_document(doc) for doc in documents]
+
+        payload: Dict[str, Any] = {"documents": normalized_docs}
+        if options is None:
+            payload["mode"] = "append"
+        else:
+            normalized_options = _normalize_dataset_options(options)
+            payload.update(normalized_options)
+            if "mode" not in payload:
+                payload["mode"] = "append"
+
+        return self._post_json(
+            self._dataset_path,
+            payload,
+            "Failed to upload dataset",
+        )
+
+    def close(self) -> None:
+        self._session.close()
+
+    def __enter__(self) -> "AiChatClient":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+    # Internal helpers -------------------------------------------------
+    def _post_json(self, path: str, body: Mapping[str, Any], error_context: str) -> Dict[str, Any]:
+        url = self._build_url(path)
+        headers = {"Content-Type": "application/json", **self._default_headers}
+
+        try:
+            response = self._session.post(
+                url,
+                json=body,
+                headers=headers,
+                timeout=self._timeout,
+            )
+        except requests.RequestException as exc:
+            raise AiChatError(f"{error_context}: {exc}") from exc
+
+        if not response.ok:
+            detail = response.text.strip() or response.reason
+            raise AiChatError(
+                f"{error_context} (status {response.status_code}): {detail}"
+            )
+
+        try:
+            return response.json()
+        except ValueError as exc:  # pragma: no cover - upstream always returns JSON
+            raise AiChatError("Response did not contain valid JSON") from exc
+
+    def _build_url(self, path: str) -> str:
+        if path.startswith("http://") or path.startswith("https://"):
+            return path
+        if not path.startswith("/"):
+            return f"{self._base_url}/{path}"
+        return f"{self._base_url}{path}"
+
+
+def _normalize_document(
+    document: Union[RetrievedDoc, Mapping[str, Any]],
+) -> Dict[str, Any]:
+    if isinstance(document, RetrievedDoc):
+        return document.to_payload()
+    if isinstance(document, Mapping):
+        return dict(document)
+    raise TypeError("retrieved_docs must contain mappings or RetrievedDoc instances")
+
+
+def _normalize_dataset_document(
+    document: Union[DatasetDocumentInput, Mapping[str, Any]],
+) -> Dict[str, Any]:
+    if isinstance(document, DatasetDocumentInput):
+        return document.to_payload()
+    if isinstance(document, Mapping):
+        return dict(document)
+    raise TypeError("documents must contain mappings or DatasetDocumentInput instances")
+
+
+def _normalize_ask_options(options: Union[AskOptions, Mapping[str, Any]]) -> Dict[str, Any]:
+    if isinstance(options, AskOptions):
+        return options.to_payload()
+    if isinstance(options, Mapping):
+        normalized: Dict[str, Any] = dict(options)
+        if "retrieved_docs" in normalized:
+            retrieved_docs = normalized["retrieved_docs"]
+            if not isinstance(retrieved_docs, Iterable):
+                raise TypeError("retrieved_docs must be an iterable")
+            normalized["retrieved_docs"] = [
+                _normalize_document(doc) for doc in retrieved_docs
+            ]
+        if "workspace" in normalized and not isinstance(normalized["workspace"], Mapping):
+            raise TypeError("workspace must be a mapping if provided")
+        if "policies" in normalized and not isinstance(normalized["policies"], Mapping):
+            raise TypeError("policies must be a mapping if provided")
+        return normalized
+    raise TypeError("options must be a mapping or AskOptions instance")
+
+
+def _normalize_dataset_options(
+    options: Union[DatasetUploadOptions, Mapping[str, Any]]
+) -> Dict[str, Any]:
+    if isinstance(options, DatasetUploadOptions):
+        return options.to_payload()
+    if isinstance(options, Mapping):
+        return dict(options)
+    raise TypeError("options must be a mapping or DatasetUploadOptions instance")


### PR DESCRIPTION
## Summary
- add a packaged Python client (`aichat`) that mirrors the TypeScript SDK and exposes helpers for asking questions and syncing datasets
- publish a comprehensive usage guide covering installation, configuration, integration patterns, and release workflow for the Python library
- surface the new Python SDK from the main README and update ignore rules for Python artifacts

## Testing
- python -m compileall src/aichat
- npx vitest run --reporter=basic

------
https://chatgpt.com/codex/tasks/task_b_68d3d4ffc48c83338a98560417569aae