### PR TITLE
Create dedicated docs page and CTA

### DIFF
--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -1,0 +1,30 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+import { DocsSection } from '@/components/docs-section';
+
+export const metadata: Metadata = {
+  title: 'Documentation | AI Help Center',
+  description:
+    'Read the complete AI Help Center SDK guide, including setup steps, environment variables, and integration examples.',
+};
+
+export default function DocsPage() {
+  return (
+    <main className="mx-auto min-h-screen max-w-6xl px-6 py-16">
+      <div className="flex items-center justify-between">
+        <Link
+          href="/"
+          className="inline-flex items-center gap-2 rounded-full border border-slate-800 bg-slate-900/60 px-4 py-2 text-sm font-medium text-slate-300 transition hover:border-slate-600 hover:text-white"
+        >
+          <span aria-hidden>←</span>
+          Back to home
+        </Link>
+      </div>
+
+      <div className="mt-12">
+        <DocsSection />
+      </div>
+    </main>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
+import Link from 'next/link';
+
 import { AskForm } from '@/components/ask-form';
-import { DocsSection } from '@/components/docs-section';
 import knowledgeBase from '@/data/knowledgeBase.json';
 import type { RetrievedDoc } from '@/lib/types';
 
@@ -65,7 +66,25 @@ export default function HomePage() {
         </aside>
       </div>
 
-      <DocsSection />
+      <section className="rounded-3xl border border-slate-800 bg-slate-900/60 p-8 shadow-xl shadow-black/40 backdrop-blur">
+        <div className="flex flex-col gap-6 sm:flex-row sm:items-center sm:justify-between">
+          <div className="space-y-3">
+            <h2 className="text-2xl font-semibold text-white sm:text-3xl">Explore the full documentation</h2>
+            <p className="text-sm text-slate-300 sm:max-w-xl sm:text-base">
+              Dive deeper into the SDK setup, environment variables, and integration examples on the dedicated documentation
+              page. Everything you need to launch the AI Help Center lives there—no scrolling required.
+            </p>
+          </div>
+
+          <Link
+            href="/docs"
+            className="inline-flex items-center justify-center gap-2 rounded-full bg-brand px-6 py-2 text-sm font-semibold text-brand-foreground shadow-glow transition hover:bg-brand/90"
+          >
+            Read the docs
+            <span aria-hidden className="text-base">↗</span>
+          </Link>
+        </div>
+      </section>
     </main>
   );
 }

--- a/components/docs-section.tsx
+++ b/components/docs-section.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
 
+type DocsSectionProps = {
+  id?: string;
+  className?: string;
+};
+
 const quickStartSteps = [
   {
     title: 'Install the SDK',
@@ -171,11 +176,15 @@ export async function syncKnowledgeBase() {
 }
 `;
 
-export function DocsSection() {
+export function DocsSection({ id = 'docs', className }: DocsSectionProps = {}) {
+  const baseClassName =
+    'rounded-3xl border border-slate-800 bg-slate-950/60 p-8 shadow-2xl shadow-black/40 backdrop-blur';
+  const sectionClassName = className ? `${baseClassName} ${className}` : baseClassName;
+
   return (
     <section
-      id="docs"
-      className="rounded-3xl border border-slate-800 bg-slate-950/60 p-8 shadow-2xl shadow-black/40 backdrop-blur"
+      id={id}
+      className={sectionClassName}
     >
       <header className="space-y-4">
         <span className="inline-flex rounded-full border border-brand/50 bg-brand/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-brand">


### PR DESCRIPTION
## Summary
- add a `/docs` route that renders the full documentation experience with metadata and an inline link back to the homepage
- replace the homepage documentation section with a call-to-action that directs readers to the new docs endpoint
- update the shared `DocsSection` component so it can be reused across routes with optional id and class name overrides

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_b_68d3dc72f5ac8333bb2e4567b1fb265f