### PR TITLE
Revamp documentation UI

### DIFF
--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -1,7 +1,20 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 
-import { DocsSection } from '@/components/docs-section';
+import { DocsSection, docsOutline } from '@/components/docs-section';
+
+const primaryNavigation = [
+  { label: 'AI Help Center', href: '/' },
+  { label: 'Documentation', href: '/docs', isActive: true },
+  { label: 'Integrations', href: '/#integrations' },
+  { label: 'Learn', href: '/#learn' },
+  { label: 'Contributing', href: '/#contributing' },
+];
+
+const utilityNavigation = [
+  { label: 'GitHub', href: 'https://github.com', external: true },
+  { label: 'Support', href: 'mailto:support@example.com', external: true },
+];
 
 export const metadata: Metadata = {
   title: 'Documentation | AI Help Center',
@@ -11,19 +24,115 @@ export const metadata: Metadata = {
 
 export default function DocsPage() {
   return (
-    <main className="mx-auto min-h-screen max-w-6xl px-6 py-16">
-      <div className="flex items-center justify-between">
-        <Link
-          href="/"
-          className="inline-flex items-center gap-2 rounded-full border border-slate-800 bg-slate-900/60 px-4 py-2 text-sm font-medium text-slate-300 transition hover:border-slate-600 hover:text-white"
-        >
-          <span aria-hidden>←</span>
-          Back to home
-        </Link>
-      </div>
+    <main className="min-h-screen bg-slate-950 text-slate-100">
+      <header className="sticky top-0 z-40 border-b border-slate-800 bg-slate-950/80 backdrop-blur">
+        <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
+          <div className="flex items-center gap-6">
+            <Link href="/" className="flex items-center gap-3 text-sm font-semibold text-white">
+              <span className="rounded-full border border-brand/40 bg-brand/10 px-3 py-1 text-xs uppercase tracking-[0.35em] text-brand">
+                AI
+              </span>
+              <span>Help Center</span>
+            </Link>
+            <nav className="hidden items-center gap-1 rounded-full border border-slate-800 bg-slate-900/60 p-1 text-sm font-medium text-slate-300 lg:flex">
+              {primaryNavigation.map((item) => (
+                <Link
+                  key={item.label}
+                  href={item.href}
+                  className={`rounded-full px-3 py-1 transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand ${
+                    item.isActive
+                      ? 'bg-slate-800 text-white shadow-glow'
+                      : 'hover:bg-slate-800/60 hover:text-white'
+                  }`}
+                >
+                  {item.label}
+                </Link>
+              ))}
+            </nav>
+          </div>
+          <div className="flex items-center gap-3 text-sm text-slate-300">
+            {utilityNavigation.map((item) => (
+              <Link
+                key={item.label}
+                href={item.href}
+                className="rounded-full border border-slate-800 bg-slate-900/60 px-3 py-1 transition hover:border-slate-700 hover:text-white"
+                {...(item.external ? { target: '_blank', rel: 'noreferrer' } : {})}
+              >
+                {item.label}
+              </Link>
+            ))}
+          </div>
+        </div>
+      </header>
 
-      <div className="mt-12">
-        <DocsSection />
+      <div className="relative">
+        <div
+          className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(99,102,241,0.12),_transparent_60%)]"
+          aria-hidden
+        />
+        <div className="relative mx-auto max-w-6xl px-6 py-12">
+          <div className="rounded-2xl border border-slate-800 bg-slate-950/60 p-4 text-sm text-slate-300 lg:hidden">
+            <p className="text-xs font-semibold uppercase tracking-[0.4em] text-slate-500">On this page</p>
+            <div className="mt-3 flex flex-wrap gap-2">
+              {docsOutline.map((section) => (
+                <Link
+                  key={section.id}
+                  href={`#${section.id}`}
+                  className="rounded-full border border-slate-800 bg-slate-900/60 px-3 py-1 text-xs font-medium text-slate-300 transition hover:border-slate-700 hover:text-white"
+                >
+                  {section.title}
+                </Link>
+              ))}
+            </div>
+          </div>
+
+          <div className="mt-10 flex flex-col gap-10 lg:mt-12 lg:flex-row">
+            <aside className="hidden w-64 shrink-0 lg:block">
+              <div className="sticky top-28 space-y-6">
+                <div className="rounded-2xl border border-brand/40 bg-brand/10 p-5 text-brand">
+                  <p className="text-xs font-semibold uppercase tracking-[0.4em] text-brand/80">OSS v0-alpha</p>
+                  <p className="mt-3 text-sm leading-relaxed text-brand/80">
+                    Preview the AI Help Center SDK docs and follow along as the platform evolves toward a stable release.
+                  </p>
+                </div>
+
+                <nav className="space-y-6 text-sm">
+                  <div>
+                    <p className="text-xs font-semibold uppercase tracking-[0.4em] text-slate-500">Documentation</p>
+                    <ul className="mt-4 space-y-2">
+                      {docsOutline.map((section) => (
+                        <li key={section.id}>
+                          <Link
+                            href={`#${section.id}`}
+                            className="group block rounded-xl border border-transparent px-3 py-2 text-sm font-medium text-slate-300 transition hover:border-slate-800 hover:bg-slate-900/60 hover:text-white"
+                          >
+                            {section.title}
+                          </Link>
+                          {section.children && (
+                            <ul className="mt-1 space-y-1 border-l border-slate-800 pl-4 text-xs text-slate-400">
+                              {section.children.map((child) => (
+                                <li key={child.id}>
+                                  <Link
+                                    href={`#${child.id}`}
+                                    className="block rounded px-2 py-1 transition hover:bg-slate-900/60 hover:text-slate-200"
+                                  >
+                                    {child.title}
+                                  </Link>
+                                </li>
+                              ))}
+                            </ul>
+                          )}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                </nav>
+              </div>
+            </aside>
+
+            <DocsSection />
+          </div>
+        </div>
       </div>
     </main>
   );

--- a/components/docs-section.tsx
+++ b/components/docs-section.tsx
@@ -5,6 +5,18 @@ type DocsSectionProps = {
   className?: string;
 };
 
+type OutlineItem = {
+  id: string;
+  title: string;
+  children?: OutlineItem[];
+};
+
+const slugify = (value: string) =>
+  value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)+/g, '');
+
 const quickStartSteps = [
   {
     title: 'Install the SDK',
@@ -27,6 +39,11 @@ const quickStartSteps = [
       'Provide the base URL for your deployed app or API gateway and call the `ask` and `uploadDataset` helpers from any client or server environment.',
   },
 ];
+
+const quickStartWithIds = quickStartSteps.map((step) => ({
+  ...step,
+  id: `quickstart-${slugify(step.title)}`,
+}));
 
 const envVariables = [
   {
@@ -144,8 +161,7 @@ export async function askSupport(question: string) {
   }
 
   return result;
-}
-`;
+}`;
 
 const datasetExample = String.raw`import { AiHelpCenterClient } from '@/lib/sdk';
 
@@ -173,143 +189,256 @@ export async function syncKnowledgeBase() {
     ],
     { mode: 'replace' },
   );
-}
-`;
+}`;
+
+export const docsOutline: OutlineItem[] = [
+  { id: 'overview', title: 'Overview' },
+  {
+    id: 'quickstart',
+    title: 'Quickstart',
+    children: quickStartWithIds.map((step) => ({ id: step.id, title: step.title })),
+  },
+  {
+    id: 'client-usage',
+    title: 'Client usage',
+    children: [
+      { id: 'client-usage-ask', title: 'Ask from any runtime' },
+      { id: 'client-usage-datasets', title: 'Synchronize your knowledge base' },
+    ],
+  },
+  { id: 'environment', title: 'Environment variables' },
+  {
+    id: 'configuration',
+    title: 'Configuration reference',
+    children: [
+      { id: 'configuration-client', title: 'Client configuration options' },
+      { id: 'configuration-ask', title: 'Ask options' },
+      { id: 'configuration-datasets', title: 'Dataset modes' },
+    ],
+  },
+  { id: 'launch', title: 'Launch checklist' },
+];
 
 export function DocsSection({ id = 'docs', className }: DocsSectionProps = {}) {
   const baseClassName =
-    'rounded-3xl border border-slate-800 bg-slate-950/60 p-8 shadow-2xl shadow-black/40 backdrop-blur';
+    'flex-1 overflow-hidden rounded-3xl border border-slate-800 bg-slate-950/60 shadow-2xl shadow-black/40 backdrop-blur';
   const sectionClassName = className ? `${baseClassName} ${className}` : baseClassName;
 
   return (
-    <section
-      id={id}
-      className={sectionClassName}
-    >
-      <header className="space-y-4">
-        <span className="inline-flex rounded-full border border-brand/50 bg-brand/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-brand">
-          Docs
-        </span>
-        <h2 className="text-3xl font-semibold leading-tight text-white sm:text-4xl">
-          Everything developers need to ship the AI Help Center SDK.
-        </h2>
-        <p className="max-w-3xl text-sm text-slate-300 sm:text-base">
-          Follow the guided quickstart, reference every environment variable, and copy ready-to-use code snippets to interact
-          with the `/api/ask` and `/api/datasets` routes. The SDK works in Node.js, serverless functions, and browser clients
-          alike.
-        </p>
-      </header>
-
-      <div className="mt-10 grid gap-6 lg:grid-cols-2 xl:grid-cols-4">
-        {quickStartSteps.map((step) => (
-          <article
-            key={step.title}
-            className="flex flex-col rounded-2xl border border-slate-800 bg-slate-900/60 p-6 text-sm text-slate-300"
-          >
-            <h3 className="text-base font-semibold text-slate-100">{step.title}</h3>
-            <p className="mt-3 leading-relaxed">{step.description}</p>
-          </article>
-        ))}
-      </div>
-
-      <div className="mt-12 grid gap-8 lg:grid-cols-2">
-        <article className="rounded-2xl border border-slate-800 bg-slate-900/70 p-6">
-          <h3 className="text-lg font-semibold text-slate-100">Ask the assistant from any runtime</h3>
-          <p className="mt-3 text-sm text-slate-300">
-            The client wraps the `/api/ask` route and validates that a question is provided before sending the request. When a
-            Gemini API key is missing, the server returns the normalized request body so you can inspect the payload without
-            incurring costs.
-          </p>
-          <pre className="mt-4 overflow-auto rounded-xl border border-slate-800 bg-slate-950/80 p-4 text-xs leading-relaxed text-slate-200 sm:text-sm">
-            <code>{askExample}</code>
-          </pre>
-        </article>
-
-        <article className="rounded-2xl border border-slate-800 bg-slate-900/70 p-6">
-          <h3 className="text-lg font-semibold text-slate-100">Synchronize your knowledge base</h3>
-          <p className="mt-3 text-sm text-slate-300">
-            Upload documentation in batches with `append` or run full refreshes with `replace`. The API persists data to
-            Supabase when credentials are present and falls back to the on-disk JSON dataset for local development.
-          </p>
-          <pre className="mt-4 overflow-auto rounded-xl border border-slate-800 bg-slate-950/80 p-4 text-xs leading-relaxed text-slate-200 sm:text-sm">
-            <code>{datasetExample}</code>
-          </pre>
-        </article>
-      </div>
-
-      <div className="mt-12 rounded-2xl border border-slate-800 bg-slate-900/60 p-6">
-        <h3 className="text-lg font-semibold text-slate-100">Environment variables</h3>
-        <p className="mt-3 text-sm text-slate-300">
-          Configure these variables to control how the server connects to Gemini and your storage layer. Only
-          <code className="mx-1 rounded bg-slate-800 px-1 py-0.5 text-xs text-slate-200">GEMINI_API_KEY</code> is required
-          for production responses.
-        </p>
-        <dl className="mt-6 grid gap-4 lg:grid-cols-2">
-          {envVariables.map((variable) => (
-            <div key={variable.name} className="rounded-xl border border-slate-800 bg-slate-950/60 p-4">
-              <dt className="font-mono text-xs uppercase tracking-wider text-brand">{variable.name}</dt>
-              <dd className="mt-2 text-sm text-slate-300">{variable.description}</dd>
-            </div>
-          ))}
-        </dl>
-      </div>
-
-      <div className="mt-12 grid gap-8 lg:grid-cols-2">
-        <article className="rounded-2xl border border-slate-800 bg-slate-900/60 p-6">
-          <h3 className="text-lg font-semibold text-slate-100">Client configuration reference</h3>
-          <dl className="mt-4 space-y-4 text-sm text-slate-300">
-            {clientConfigOptions.map((option) => (
-              <div key={option.name}>
-                <dt className="font-semibold text-slate-100">{option.name}</dt>
-                <dd className="mt-1 leading-relaxed">{option.description}</dd>
+    <section id={id} className={sectionClassName}>
+      <div className="relative">
+        <div
+          className="pointer-events-none absolute inset-x-0 top-0 h-56 bg-[radial-gradient(circle_at_top,_rgba(99,102,241,0.25),_transparent_60%)]"
+          aria-hidden
+        />
+        <article className="relative space-y-16 px-8 py-12 md:px-12">
+          <section id="overview" className="scroll-mt-32 space-y-6">
+            <header className="space-y-4">
+              <div className="inline-flex items-center gap-3 rounded-full border border-slate-800 bg-slate-900/70 px-4 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-slate-400">
+                <span>Docs</span>
+                <span className="text-brand">AI</span>
               </div>
-            ))}
-          </dl>
-        </article>
+              <h1 className="text-3xl font-semibold text-white md:text-4xl">Overview</h1>
+              <p className="max-w-2xl text-base leading-relaxed text-slate-300">
+                Everything developers need to ship the AI Help Center SDK. Follow the guided quickstart, reference every
+                environment variable, and copy ready-to-use code snippets to interact with the `/api/ask` and `/api/datasets`
+                routes.
+              </p>
+            </header>
 
-        <article className="rounded-2xl border border-slate-800 bg-slate-900/60 p-6">
-          <h3 className="text-lg font-semibold text-slate-100">Ask options & dataset modes</h3>
-          <div className="mt-4 space-y-6 text-sm text-slate-300">
-            <dl className="space-y-4">
-              {askOptions.map((option) => (
-                <div key={option.name}>
-                  <dt className="font-semibold text-slate-100">{option.name}</dt>
-                  <dd className="mt-1 leading-relaxed">{option.description}</dd>
+            <div className="rounded-2xl border border-amber-500/40 bg-amber-500/10 px-5 py-4 text-amber-100">
+              <p className="text-xs font-semibold uppercase tracking-[0.4em] text-amber-200">Alpha notice</p>
+              <p className="mt-2 text-sm leading-relaxed">
+                These docs cover the v0-alpha release of the AI Help Center SDK. Components and APIs may evolve before the
+                stable launch. Keep an eye on the changelog and upgrade guides for breaking changes.
+              </p>
+            </div>
+
+            <div className="space-y-4 text-sm leading-relaxed text-slate-300">
+              <p>
+                The SDK exposes strongly typed helpers for asking the assistant and synchronizing datasets. It is designed to be
+                framework agnostic and can be called from browsers, Node.js scripts, or background workers with the same
+                configuration object.
+              </p>
+              <p>
+                Serverless-friendly API routes power retrieval, prompt building, and Gemini generation. When Gemini credentials
+                are absent, the application falls back to a deterministic mock response so you can integrate safely without
+                incurring token costs.
+              </p>
+            </div>
+          </section>
+
+          <section id="quickstart" className="scroll-mt-32 space-y-6 border-t border-slate-800 pt-12">
+            <div className="space-y-3">
+              <p className="text-xs font-semibold uppercase tracking-[0.4em] text-slate-500">Quickstart</p>
+              <h2 className="text-2xl font-semibold text-white">Ship the assistant in minutes</h2>
+              <p className="max-w-2xl text-sm leading-relaxed text-slate-300">
+                Walk through the essential steps required to deploy the SDK inside your own product experience. Each card links to
+                configuration details and code samples available on this page.
+              </p>
+            </div>
+
+            <ol className="space-y-4">
+              {quickStartWithIds.map((step, index) => (
+                <li
+                  key={step.title}
+                  id={step.id}
+                  className="flex gap-4 rounded-2xl border border-slate-800 bg-slate-900/60 p-5 transition hover:border-slate-700 hover:bg-slate-900/80"
+                >
+                  <span className="flex h-10 w-10 items-center justify-center rounded-full border border-brand/40 bg-brand/10 text-sm font-semibold text-brand">
+                    {String(index + 1).padStart(2, '0')}
+                  </span>
+                  <div className="space-y-2">
+                    <h3 className="text-base font-semibold text-slate-100">{step.title}</h3>
+                    <p className="text-sm leading-relaxed text-slate-300">{step.description}</p>
+                  </div>
+                </li>
+              ))}
+            </ol>
+          </section>
+
+          <section id="client-usage" className="scroll-mt-32 space-y-6 border-t border-slate-800 pt-12">
+            <div className="space-y-3">
+              <p className="text-xs font-semibold uppercase tracking-[0.4em] text-slate-500">Client usage</p>
+              <h2 className="text-2xl font-semibold text-white">Interact with the SDK from any runtime</h2>
+              <p className="max-w-2xl text-sm leading-relaxed text-slate-300">
+                The client wraps REST endpoints with minimal configuration. Provide your deployment&apos;s base URL, optionally add
+                custom headers, and call the helper methods wherever you have access to `fetch`.
+              </p>
+            </div>
+
+            <div className="space-y-8">
+              <article
+                id="client-usage-ask"
+                className="rounded-2xl border border-slate-800 bg-slate-900/70 p-6 shadow-inner shadow-black/20"
+              >
+                <h3 className="text-lg font-semibold text-slate-100">Ask the assistant from any runtime</h3>
+                <p className="mt-3 text-sm leading-relaxed text-slate-300">
+                  The client validates that a question is supplied before reaching the server. Missing Gemini credentials trigger a
+                  simulated payload response, letting you verify prompts and workspace metadata during development without
+                  consuming tokens.
+                </p>
+                <pre className="mt-4 overflow-x-auto rounded-2xl border border-slate-800 bg-slate-950/90 p-5 text-xs leading-relaxed text-slate-200">
+                  <code>{askExample}</code>
+                </pre>
+              </article>
+
+              <article
+                id="client-usage-datasets"
+                className="rounded-2xl border border-slate-800 bg-slate-900/70 p-6 shadow-inner shadow-black/20"
+              >
+                <h3 className="text-lg font-semibold text-slate-100">Synchronize your knowledge base</h3>
+                <p className="mt-3 text-sm leading-relaxed text-slate-300">
+                  Upload documentation in batches with <code className="mx-1 rounded bg-slate-800 px-1 py-0.5 text-xs text-slate-200">append</code> or
+                  run full refreshes with <code className="mx-1 rounded bg-slate-800 px-1 py-0.5 text-xs text-slate-200">replace</code>. The API persists data to Supabase when
+                  credentials are present and falls back to the on-disk JSON dataset for local development.
+                </p>
+                <pre className="mt-4 overflow-x-auto rounded-2xl border border-slate-800 bg-slate-950/90 p-5 text-xs leading-relaxed text-slate-200">
+                  <code>{datasetExample}</code>
+                </pre>
+              </article>
+            </div>
+          </section>
+
+          <section id="environment" className="scroll-mt-32 space-y-6 border-t border-slate-800 pt-12">
+            <div className="space-y-3">
+              <p className="text-xs font-semibold uppercase tracking-[0.4em] text-slate-500">Configuration</p>
+              <h2 className="text-2xl font-semibold text-white">Environment variables</h2>
+              <p className="max-w-2xl text-sm leading-relaxed text-slate-300">
+                Configure these variables to control how the server connects to Gemini and your storage layer. Only
+                <code className="mx-1 rounded bg-slate-800 px-1 py-0.5 text-xs text-slate-200">GEMINI_API_KEY</code> is required for production responses.
+              </p>
+            </div>
+
+            <dl className="grid gap-4 md:grid-cols-2">
+              {envVariables.map((variable) => (
+                <div key={variable.name} className="rounded-2xl border border-slate-800 bg-slate-950/60 p-4">
+                  <dt className="font-mono text-xs uppercase tracking-wider text-brand">{variable.name}</dt>
+                  <dd className="mt-2 text-sm leading-relaxed text-slate-300">{variable.description}</dd>
                 </div>
               ))}
             </dl>
-            <div>
-              <h4 className="text-sm font-semibold uppercase tracking-wider text-slate-400">Dataset modes</h4>
-              <ul className="mt-3 space-y-3">
-                {datasetModes.map((mode) => (
-                  <li key={mode.name} className="rounded-xl border border-slate-800 bg-slate-950/60 p-4">
-                    <p className="font-semibold text-slate-100">{mode.name}</p>
-                    <p className="mt-2 text-sm leading-relaxed text-slate-300">{mode.description}</p>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          </div>
-        </article>
-      </div>
+          </section>
 
-      <div className="mt-12 grid gap-6 lg:grid-cols-2">
-        <article className="rounded-2xl border border-brand/40 bg-brand/10 p-6 text-sm text-brand">
-          <h3 className="text-base font-semibold text-brand">Debug-friendly defaults</h3>
-          <p className="mt-2 text-brand/80">
-            Missing Gemini credentials? The server responds with the normalized request payload so you can verify prompts and
-            workspace metadata while developing locally. As soon as you add the API key, responses switch to live Gemini
-            generations automatically.
-          </p>
-        </article>
-        <article className="rounded-2xl border border-slate-800 bg-slate-900/60 p-6 text-sm text-slate-300">
-          <h3 className="text-base font-semibold text-slate-100">Production launch checklist</h3>
-          <ul className="mt-3 list-disc space-y-2 pl-5">
-            <li>Enable Supabase credentials or provide a scheduled dataset sync job.</li>
-            <li>Set custom `defaultHeaders` if your routes require authentication or tenant routing.</li>
-            <li>Use the `json` mode for structured hand-offs to chat widgets or CRM integrations.</li>
-            <li>Monitor `/api/datasets` uploads—every call returns counts so you can alert on drift.</li>
-          </ul>
+          <section id="configuration" className="scroll-mt-32 space-y-8 border-t border-slate-800 pt-12">
+            <div className="space-y-3">
+              <p className="text-xs font-semibold uppercase tracking-[0.4em] text-slate-500">Reference</p>
+              <h2 className="text-2xl font-semibold text-white">Configuration reference</h2>
+              <p className="max-w-2xl text-sm leading-relaxed text-slate-300">
+                Deep dive into the available options for the SDK client, the ask helper, and dataset synchronization. Combine these
+                settings to tailor the assistant&apos;s tone, retrieval strategy, and routing.
+              </p>
+            </div>
+
+            <div className="space-y-8">
+              <article id="configuration-client" className="space-y-4">
+                <h3 className="text-lg font-semibold text-slate-100">Client configuration options</h3>
+                <dl className="space-y-4 text-sm leading-relaxed text-slate-300">
+                  {clientConfigOptions.map((option) => (
+                    <div key={option.name}>
+                      <dt className="font-semibold text-slate-100">{option.name}</dt>
+                      <dd className="mt-1">{option.description}</dd>
+                    </div>
+                  ))}
+                </dl>
+              </article>
+
+              <article id="configuration-ask" className="space-y-4">
+                <h3 className="text-lg font-semibold text-slate-100">Ask options</h3>
+                <dl className="space-y-4 text-sm leading-relaxed text-slate-300">
+                  {askOptions.map((option) => (
+                    <div key={option.name}>
+                      <dt className="font-semibold text-slate-100">{option.name}</dt>
+                      <dd className="mt-1">{option.description}</dd>
+                    </div>
+                  ))}
+                </dl>
+              </article>
+
+              <article id="configuration-datasets" className="space-y-4">
+                <h3 className="text-lg font-semibold text-slate-100">Dataset modes</h3>
+                <ul className="space-y-3 text-sm leading-relaxed text-slate-300">
+                  {datasetModes.map((mode) => (
+                    <li key={mode.name} className="rounded-2xl border border-slate-800 bg-slate-950/60 p-4">
+                      <p className="font-semibold text-slate-100">{mode.name}</p>
+                      <p className="mt-2">{mode.description}</p>
+                    </li>
+                  ))}
+                </ul>
+              </article>
+            </div>
+          </section>
+
+          <section id="launch" className="scroll-mt-32 space-y-6 border-t border-slate-800 pt-12">
+            <div className="space-y-3">
+              <p className="text-xs font-semibold uppercase tracking-[0.4em] text-slate-500">Launch checklist</p>
+              <h2 className="text-2xl font-semibold text-white">Prep for production</h2>
+              <p className="max-w-2xl text-sm leading-relaxed text-slate-300">
+                Finalize your rollout by validating dataset freshness, monitoring observability hooks, and coordinating support
+                hand-offs with your team.
+              </p>
+            </div>
+
+            <div className="grid gap-6 lg:grid-cols-2">
+              <article className="rounded-2xl border border-slate-800 bg-slate-900/60 p-6 text-sm leading-relaxed text-slate-300">
+                <h3 className="text-base font-semibold text-slate-100">Production launch checklist</h3>
+                <ul className="mt-3 list-disc space-y-2 pl-5">
+                  <li>Enable Supabase credentials or schedule a recurring dataset sync job.</li>
+                  <li>Set custom <code className="mx-1 rounded bg-slate-800 px-1 py-0.5 text-xs text-slate-200">defaultHeaders</code> if routes require authentication or tenant routing.</li>
+                  <li>Use the <code className="mx-1 rounded bg-slate-800 px-1 py-0.5 text-xs text-slate-200">json</code> mode for structured hand-offs to chat widgets or CRMs.</li>
+                  <li>Monitor `/api/datasets` uploads—every response includes counts you can alert on.</li>
+                </ul>
+              </article>
+
+              <article className="rounded-2xl border border-brand/40 bg-brand/10 p-6 text-sm leading-relaxed text-brand">
+                <h3 className="text-base font-semibold text-brand">Debug-friendly defaults</h3>
+                <p className="mt-2 text-brand/80">
+                  Missing Gemini credentials? The server responds with the normalized request payload so you can verify prompts and
+                  workspace metadata while developing locally. Add the API key at any time to switch to live Gemini generations.
+                </p>
+              </article>
+            </div>
+          </section>
         </article>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- redesign the documentation page layout with a sticky header, pill navigation, and gradient backdrop to mirror the requested LangGraph-style experience
- create a structured docs outline with section anchors powering a sidebar and mobile jump list
- refresh the content blocks into article-style sections covering quickstart, client usage, configuration, and launch guidance

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_b_68d4030176608333bb39877add1ffa5b