### PR TITLE
Add global navigation and simplify homepage layout

### DIFF
--- a/app/docs/page.jsx
+++ b/app/docs/page.jsx
@@ -1,5 +1,3 @@
-import Link from 'next/link';
-
 import { DocsSection } from '@/components/docs-section';
 
 export const metadata = {
@@ -9,20 +7,21 @@ export const metadata = {
 
 export default function DocsPage() {
   return (
-    <main className="relative mx-auto min-h-screen max-w-7xl px-6 py-16">
+    <main className="relative mx-auto min-h-screen max-w-5xl px-6 pb-20 pt-24">
       <div className="pointer-events-none absolute inset-x-0 -top-32 -z-10 flex justify-center">
         <div className="h-64 w-full max-w-5xl rounded-full bg-brand/30 blur-3xl" />
       </div>
 
-      <div className="flex items-center justify-between">
-        <Link
-          href="/"
-          className="inline-flex items-center gap-2 rounded-full border border-slate-800/80 bg-slate-950/60 px-4 py-2 text-sm font-medium text-slate-300 shadow-2xl shadow-black/30 transition hover:border-brand hover:text-white"
-        >
-          <span aria-hidden>←</span>
-          Back to home
-        </Link>
-      </div>
+      <header className="space-y-4 text-center sm:text-left">
+        <span className="inline-flex rounded-full border border-brand/50 bg-brand/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-brand">
+          Documentation
+        </span>
+        <h1 className="text-4xl font-semibold leading-tight text-white sm:text-5xl">All of the answers, in one place.</h1>
+        <p className="text-base text-slate-300 sm:text-lg">
+          Explore configuration steps, SDK usage, and integration tips without leaving the page. Everything you need to ship the
+          AI Help Center lives below.
+        </p>
+      </header>
 
       <div className="mt-12">
         <DocsSection />

--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -1,6 +1,7 @@
 import { Inter } from 'next/font/google';
 
 import './globals.css';
+import { Navbar } from '@/components/navbar';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -12,7 +13,10 @@ export const metadata = {
 export default function RootLayout({ children }) {
   return (
     <html lang="en" className="h-full">
-      <body className={`${inter.className} min-h-screen bg-slate-950`}>{children}</body>
+      <body className={`${inter.className} min-h-screen bg-slate-950 antialiased`}>
+        <Navbar />
+        {children}
+      </body>
     </html>
   );
 }

--- a/app/page.jsx
+++ b/app/page.jsx
@@ -1,5 +1,3 @@
-import Link from 'next/link';
-
 import { AskForm } from '@/components/ask-form';
 import knowledgeBase from '@/data/knowledgeBase.json';
 
@@ -7,81 +5,57 @@ const documents = Array.isArray(knowledgeBase) ? knowledgeBase : [];
 
 export default function HomePage() {
   return (
-    <main className="mx-auto min-h-screen max-w-6xl space-y-16 px-6 py-16">
-      <div className="flex flex-col gap-12 lg:flex-row lg:gap-16">
-        <section className="lg:w-3/5">
-          <header className="space-y-4">
-            <span className="inline-flex rounded-full border border-brand/50 bg-brand/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-brand">
-              AI Help Center
-            </span>
-            <h1 className="text-4xl font-semibold leading-tight text-white sm:text-5xl">
-              Ship a production-ready RAG assistant in minutes.
-            </h1>
-            <p className="max-w-xl text-base text-slate-300 sm:text-lg">
-              Ask questions about your product documentation, generate structured JSON responses for chat widgets, and keep
-              citations front-and-center. Everything runs on Next.js, Tailwind CSS, and Google Gemini.
-            </p>
-          </header>
+    <main className="mx-auto min-h-screen max-w-6xl space-y-16 px-6 pb-20 pt-24">
+      <section className="space-y-10">
+        <header className="space-y-4">
+          <span className="inline-flex rounded-full border border-brand/50 bg-brand/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-brand">
+            AI Help Center
+          </span>
+          <h1 className="text-4xl font-semibold leading-tight text-white sm:text-5xl">
+            Ship a production-ready RAG assistant in minutes.
+          </h1>
+          <p className="max-w-xl text-base text-slate-300 sm:text-lg">
+            Ask questions about your product documentation, generate structured JSON responses for chat widgets, and keep
+            citations front-and-center. Everything runs on Next.js, Tailwind CSS, and Google Gemini.
+          </p>
+        </header>
 
-          <div className="mt-12 rounded-3xl border border-slate-800 bg-slate-900/60 p-8 shadow-xl shadow-black/40 backdrop-blur">
-            <AskForm />
-          </div>
-        </section>
+        <div className="rounded-3xl border border-slate-800 bg-slate-900/60 p-8 shadow-xl shadow-black/40 backdrop-blur">
+          <AskForm />
+        </div>
+      </section>
 
-        <aside className="lg:w-2/5">
-          <div className="sticky top-16 space-y-6">
-            <div className="rounded-3xl border border-slate-800 bg-slate-900/40 p-6">
-              <h2 className="text-lg font-semibold text-slate-100">Knowledge base preview</h2>
-              <p className="mt-2 text-sm text-slate-400">
-                The retriever loads documents from Supabase when configured, with a JSON fallback for local development. Here are
-                the sample entries bundled with the project.
-              </p>
-              <ul className="mt-6 space-y-4 text-sm text-slate-300">
-                {documents.slice(0, 5).map((doc) => (
-                  <li key={doc.id ?? doc.title} className="rounded-xl border border-slate-800/80 bg-slate-950/40 p-4">
-                    <p className="text-xs uppercase tracking-wide text-slate-500">{doc.created_at ?? 'N/A'}</p>
-                    <p className="mt-1 font-semibold text-slate-100">{doc.title}</p>
-                    <p className="mt-2 text-slate-400">{doc.text}</p>
-                    <a href={doc.url} target="_blank" rel="noreferrer" className="mt-3 inline-flex items-center gap-2 text-sm">
-                      View document
-                      <span aria-hidden className="text-brand">↗</span>
-                    </a>
-                  </li>
-                ))}
-              </ul>
-            </div>
+      <section className="grid gap-6 lg:grid-cols-2">
+        <div className="rounded-3xl border border-slate-800 bg-slate-900/40 p-6">
+          <h2 className="text-lg font-semibold text-slate-100">Knowledge base preview</h2>
+          <p className="mt-2 text-sm text-slate-400">
+            The retriever loads documents from Supabase when configured, with a JSON fallback for local development. Here are
+            the sample entries bundled with the project.
+          </p>
+          <ul className="mt-6 space-y-4 text-sm text-slate-300">
+            {documents.slice(0, 5).map((doc) => (
+              <li key={doc.id ?? doc.title} className="rounded-xl border border-slate-800/80 bg-slate-950/40 p-4">
+                <p className="text-xs uppercase tracking-wide text-slate-500">{doc.created_at ?? 'N/A'}</p>
+                <p className="mt-1 font-semibold text-slate-100">{doc.title}</p>
+                <p className="mt-2 text-slate-400">{doc.text}</p>
+                <a href={doc.url} target="_blank" rel="noreferrer" className="mt-3 inline-flex items-center gap-2 text-sm">
+                  View document
+                  <span aria-hidden className="text-brand">↗</span>
+                </a>
+              </li>
+            ))}
+          </ul>
+        </div>
 
-            <div className="rounded-3xl border border-brand/40 bg-brand/10 p-6 text-sm text-brand">
-              <h3 className="text-base font-semibold text-brand">Deploy-ready architecture</h3>
-              <p className="mt-2 text-brand/80">
-                This Next.js rewrite keeps the typed Gemini client, retrieval pipeline, and Supabase integration from the original
-                Express app while modernizing the UX with Tailwind CSS.
-              </p>
-              <p className="mt-3 text-brand/80">
-                Swap in your credentials, point to your Supabase table, and the assistant is ready for production workloads.
-              </p>
-            </div>
-          </div>
-        </aside>
-      </div>
-
-      <section className="rounded-3xl border border-slate-800 bg-slate-900/60 p-8 shadow-xl shadow-black/40 backdrop-blur">
-        <div className="flex flex-col gap-6 sm:flex-row sm:items-center sm:justify-between">
-          <div className="space-y-3">
-            <h2 className="text-2xl font-semibold text-white sm:text-3xl">Explore the full documentation</h2>
-            <p className="text-sm text-slate-300 sm:max-w-xl sm:text-base">
-              Dive deeper into the SDK setup, environment variables, and integration examples on the dedicated documentation
-              page. Everything you need to launch the AI Help Center lives there—no scrolling required.
-            </p>
-          </div>
-
-          <Link
-            href="/docs"
-            className="inline-flex items-center justify-center gap-2 rounded-full bg-brand px-6 py-2 text-sm font-semibold text-brand-foreground shadow-glow transition hover:bg-brand/90"
-          >
-            Read the docs
-            <span aria-hidden className="text-base">↗</span>
-          </Link>
+        <div className="rounded-3xl border border-brand/40 bg-brand/10 p-6 text-sm text-brand">
+          <h3 className="text-base font-semibold text-brand">Deploy-ready architecture</h3>
+          <p className="mt-2 text-brand/80">
+            This Next.js rewrite keeps the typed Gemini client, retrieval pipeline, and Supabase integration from the original
+            Express app while modernizing the UX with Tailwind CSS.
+          </p>
+          <p className="mt-3 text-brand/80">
+            Swap in your credentials, point to your Supabase table, and the assistant is ready for production workloads.
+          </p>
         </div>
       </section>
     </main>

--- a/components/navbar.jsx
+++ b/components/navbar.jsx
@@ -1,0 +1,44 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+const navigationLinks = [
+  { href: '/', label: 'Home' },
+  { href: '/docs', label: 'Docs' },
+];
+
+export function Navbar() {
+  const pathname = usePathname();
+
+  return (
+    <header className="sticky top-0 z-50 border-b border-slate-800/60 bg-slate-950/80 backdrop-blur">
+      <div className="mx-auto flex w-full max-w-6xl items-center justify-between px-6 py-4 lg:max-w-7xl">
+        <Link
+          href="/"
+          className="inline-flex items-center gap-2 rounded-full border border-brand/50 bg-brand/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-brand transition hover:border-brand/80 hover:bg-brand/20"
+        >
+          AI Help Center
+        </Link>
+
+        <nav className="flex items-center gap-6 text-sm font-medium">
+          {navigationLinks.map(({ href, label }) => {
+            const isActive = pathname === href || (href !== '/' && pathname.startsWith(href));
+
+            return (
+              <Link
+                key={href}
+                href={href}
+                className={`transition hover:text-white ${
+                  isActive ? 'text-white' : 'text-slate-300'
+                }`}
+              >
+                {label}
+              </Link>
+            );
+          })}
+        </nav>
+      </div>
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable sticky navbar that highlights the active route and links to docs
- embed the navbar in the root layout and polish hero/knowledge preview sections on the homepage
- refresh the documentation page hero to work with the new navigation

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_b_68d42d548aa4833399b059ad8c725afb