### PR TITLE
Handle missing Supabase knowledge base table

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,17 @@ A production-ready AI Help Center rebuilt with **Next.js 14**, **Tailwind CSS**,
 
    - When `GEMINI_API_KEY` is omitted, the API returns the Gemini request payload so you can inspect prompts safely in development.
    - When Supabase credentials are missing, the retriever falls back to the bundled JSON knowledge base.
+   - If you enable Supabase, ensure the knowledge base table exists. Run this SQL in the SQL editor (adjust the schema/name as needed):
+
+     ```sql
+     create table if not exists public.knowledge_base (
+       id uuid primary key,
+       title text not null,
+       text text not null,
+       url text not null,
+       created_at timestamptz default now()
+     );
+     ```
 
 3. **Run the development server**
 

--- a/lib/retrieval/knowledgeBase.js
+++ b/lib/retrieval/knowledgeBase.js
@@ -44,7 +44,15 @@ export class SupabaseKnowledgeBase {
       const { data, error } = await this.client.from(this.table).select('id, title, text, url, created_at');
 
       if (error) {
-        console.error('Failed to query Supabase knowledge base:', error);
+        if (error.code === 'PGRST205') {
+          console.warn(
+            `Supabase knowledge base table "${this.table}" not found. ` +
+              'Create the table or remove the Supabase credentials to fall back to the local JSON store.',
+          );
+        } else {
+          console.error('Failed to query Supabase knowledge base:', error);
+        }
+
         return [];
       }
 

--- a/tests/supabaseKnowledgeBase.test.js
+++ b/tests/supabaseKnowledgeBase.test.js
@@ -103,4 +103,28 @@ describe('SupabaseKnowledgeBase', () => {
     expect(documents).toEqual([]);
     expect(consoleError).toHaveBeenCalled();
   });
+
+  it('warns when the knowledge base table is missing', async () => {
+    const stub = createClientStub();
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    stub.select.mockResolvedValue({
+      data: null,
+      error: { code: 'PGRST205', message: 'table not found' },
+    });
+
+    const knowledgeBase = new SupabaseKnowledgeBase({
+      url: 'https://example.supabase.co',
+      key: 'test-key',
+      table: 'knowledge_base',
+      client: stub.client,
+    });
+
+    const documents = await knowledgeBase.fetchDocuments();
+
+    expect(documents).toEqual([]);
+    expect(consoleWarn).toHaveBeenCalledWith(
+      'Supabase knowledge base table "knowledge_base" not found. Create the table or remove the Supabase credentials to fall back to the local JSON store.',
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- warn with actionable guidance when the Supabase knowledge base table is missing instead of logging an error
- document the SQL needed to provision the knowledge base table in Supabase
- add regression test covering the missing table scenario

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d4302252ac8333bd1a9a12ba4aaa06